### PR TITLE
Optimize backend selection for dnscheck

### DIFF
--- a/dnscheck.sh
+++ b/dnscheck.sh
@@ -7,7 +7,7 @@ done
 
 get_backends()
 {
-  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | cut -d '"' -f 2)
+  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | grep -v nodnscheck | cut -d '"' -f 2)
   > /tmp/backend.list
   for backend in ${BACKEND_LIST}; do
 

--- a/dnscheck.sh
+++ b/dnscheck.sh
@@ -7,7 +7,7 @@ done
 
 get_backends()
 {
-  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | grep -v nodnscheck | cut -d '"' -f 2)
+  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | grep -v nodnscheck | cut -d '"' -f 2 | sort | uniq )
   > /tmp/backend.list
   for backend in ${BACKEND_LIST}; do
 

--- a/dnscheck.sh
+++ b/dnscheck.sh
@@ -7,7 +7,7 @@ done
 
 get_backends()
 {
-  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | grep '.host' | cut -d '"' -f 2)
+  BACKEND_LIST=$(varnishadm vcl.show $(varnishadm vcl.list | grep active | awk '{print $4}') | egrep '^[ \t]+\.host[ \t]*=' | cut -d '"' -f 2)
   > /tmp/backend.list
   for backend in ${BACKEND_LIST}; do
 


### PR DESCRIPTION
Hi

The purpose of this PR is to enhance the selection of backends being monitored by dnscheck:
- Better identification of backends
- Allow to disable dns check for some backends  (adding nodnscheck in the line)
- Get unique backends

Best regards